### PR TITLE
Feature: Max IV Form page

### DIFF
--- a/lib/blocks/pages/max_iv_form/a_max_iv_form_state.dart
+++ b/lib/blocks/pages/max_iv_form/a_max_iv_form_state.dart
@@ -1,0 +1,8 @@
+import 'package:equatable/equatable.dart';
+
+abstract class AMaxIVFormState extends Equatable{
+  const AMaxIVFormState();
+
+  @override
+  List<Object> get props => <Object>[];
+}

--- a/lib/blocks/pages/max_iv_form/max_iv_form_cubit.dart
+++ b/lib/blocks/pages/max_iv_form/max_iv_form_cubit.dart
@@ -1,0 +1,15 @@
+import 'package:breeder/blocks/pages/max_iv_form/a_max_iv_form_state.dart';
+import 'package:breeder/blocks/pages/max_iv_form/states/max_iv_form_init_state.dart';
+import 'package:breeder/blocks/pages/max_iv_form/states/max_iv_form_sum_calculated_state.dart';
+import 'package:breeder/shared/models/max_iv_form/max_iv_form_model.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class MaxIVFormCubit extends Cubit<AMaxIVFormState> {
+  late MaxIVFormModel maxIVFormModel = MaxIVFormModel();
+
+  MaxIVFormCubit() : super(MaxIVFormInitState());
+
+  void calculateSum() {
+    emit(MaxIVFormSumCalculatedState(maxIVFormSum: maxIVFormModel.calculateWeightedSum()));
+  }
+}

--- a/lib/blocks/pages/max_iv_form/states/max_iv_form_init_state.dart
+++ b/lib/blocks/pages/max_iv_form/states/max_iv_form_init_state.dart
@@ -1,0 +1,3 @@
+import 'package:breeder/blocks/pages/max_iv_form/a_max_iv_form_state.dart';
+
+class MaxIVFormInitState extends AMaxIVFormState {}

--- a/lib/blocks/pages/max_iv_form/states/max_iv_form_sum_calculated_state.dart
+++ b/lib/blocks/pages/max_iv_form/states/max_iv_form_sum_calculated_state.dart
@@ -1,0 +1,10 @@
+import 'package:breeder/blocks/pages/max_iv_form/a_max_iv_form_state.dart';
+
+class MaxIVFormSumCalculatedState extends AMaxIVFormState {
+  final int maxIVFormSum;
+
+  const MaxIVFormSumCalculatedState({required this.maxIVFormSum});
+
+  @override
+  List<Object> get props => <Object>[maxIVFormSum];
+}

--- a/lib/config/locator.dart
+++ b/lib/config/locator.dart
@@ -1,0 +1,12 @@
+import 'package:breeder/blocks/pages/max_iv_form/max_iv_form_cubit.dart';
+import 'package:get_it/get_it.dart';
+
+final GetIt globalLocator = GetIt.I;
+
+Future<void> initLocator() async {
+  _initControllers();
+}
+
+void _initControllers() {
+  globalLocator.registerLazySingleton<MaxIVFormCubit>(MaxIVFormCubit.new);
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,9 @@
+import 'package:breeder/config/locator.dart';
 import 'package:breeder/shared/router/router.dart';
 import 'package:flutter/material.dart';
 
-void main() {
+Future<void> main() async {
+  await initLocator();
   runApp(const CoreApp());
 }
 

--- a/lib/shared/controllers/max_iv_text_editing_controllers.dart
+++ b/lib/shared/controllers/max_iv_text_editing_controllers.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class MaxIVTextEditingControllers {
+  late List<TextEditingController> maxIVTextEditingControllersList;
+
+  MaxIVTextEditingControllers() {
+    initMaxIVTextEditingControllers();
+  }
+
+  void initMaxIVTextEditingControllers() {
+    maxIVTextEditingControllersList = List<TextEditingController>.generate(5, (_) => TextEditingController());
+  }
+
+
+  // TODO(balladyna): Dispose is currently nowhere used. Consider where should be call
+
+  void dispose() {
+    for (TextEditingController textEditingController in maxIVTextEditingControllersList) {
+      textEditingController.dispose();
+    }
+  }
+}

--- a/lib/shared/models/max_iv_form/max_iv_form_model.dart
+++ b/lib/shared/models/max_iv_form/max_iv_form_model.dart
@@ -1,0 +1,39 @@
+import 'package:breeder/shared/controllers/max_iv_text_editing_controllers.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class MaxIVFormModel {
+  late List<TextEditingController> maxIVTextEditingControllersList;
+
+  MaxIVFormModel() {
+    MaxIVTextEditingControllers maxIVTextEditingControllers = MaxIVTextEditingControllers()..initMaxIVTextEditingControllers();
+
+    maxIVTextEditingControllersList = maxIVTextEditingControllers.maxIVTextEditingControllersList;
+  }
+
+  int calculateAmountLeft(int inputWeight) {
+    int amountLeft = ((32 - calculateWeightedSum()) / inputWeight).truncate();
+
+    return amountLeft;
+  }
+
+  int calculateWeightedSum() {
+    List<int> amountList = getAmountList();
+
+    amountList[1] *= 2;
+    amountList[2] *= 4;
+    amountList[3] *= 8;
+    amountList[4] *= 16;
+
+    int formsSum = amountList.fold(0, (int previousValue, int element) => previousValue + element);
+
+    return formsSum;
+  }
+
+  List<int> getAmountList() {
+    List<int> amountList =
+        maxIVTextEditingControllersList.map((TextEditingController textEditingController) => int.tryParse(textEditingController.text) ?? 0).toList();
+
+    return amountList;
+  }
+}

--- a/lib/shared/router/router.dart
+++ b/lib/shared/router/router.dart
@@ -8,6 +8,7 @@ class AppRouter extends $AppRouter {
     return <AutoRoute>[
       AutoRoute(page: MainMenuRoute.page, initial: true),
       AutoRoute(page: NewBreedingRoute.page),
+      AutoRoute(page: MaxIVFormRoute.page),
     ];
   }
 }

--- a/lib/shared/router/router.gr.dart
+++ b/lib/shared/router/router.gr.dart
@@ -8,25 +8,33 @@
 // coverage:ignore-file
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'package:auto_route/auto_route.dart' as _i3;
+import 'package:auto_route/auto_route.dart' as _i4;
 import 'package:breeder/views/pages/main_menu_page.dart' as _i1;
-import 'package:breeder/views/pages/new_breeding_page.dart' as _i2;
+import 'package:breeder/views/pages/max_iv_form_page/max_iv_form_page.dart'
+    as _i2;
+import 'package:breeder/views/pages/new_breeding_page.dart' as _i3;
 
-abstract class $AppRouter extends _i3.RootStackRouter {
+abstract class $AppRouter extends _i4.RootStackRouter {
   $AppRouter({super.navigatorKey});
 
   @override
-  final Map<String, _i3.PageFactory> pagesMap = {
+  final Map<String, _i4.PageFactory> pagesMap = {
     MainMenuRoute.name: (routeData) {
-      return _i3.AutoRoutePage<dynamic>(
+      return _i4.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: const _i1.MainMenuPage(),
       );
     },
-    NewBreedingRoute.name: (routeData) {
-      return _i3.AutoRoutePage<dynamic>(
+    MaxIVFormRoute.name: (routeData) {
+      return _i4.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: const _i2.NewBreedingPage(),
+        child: const _i2.MaxIVFormPage(),
+      );
+    },
+    NewBreedingRoute.name: (routeData) {
+      return _i4.AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const _i3.NewBreedingPage(),
       );
     },
   };
@@ -34,8 +42,8 @@ abstract class $AppRouter extends _i3.RootStackRouter {
 
 /// generated route for
 /// [_i1.MainMenuPage]
-class MainMenuRoute extends _i3.PageRouteInfo<void> {
-  const MainMenuRoute({List<_i3.PageRouteInfo>? children})
+class MainMenuRoute extends _i4.PageRouteInfo<void> {
+  const MainMenuRoute({List<_i4.PageRouteInfo>? children})
       : super(
           MainMenuRoute.name,
           initialChildren: children,
@@ -43,13 +51,27 @@ class MainMenuRoute extends _i3.PageRouteInfo<void> {
 
   static const String name = 'MainMenuRoute';
 
-  static const _i3.PageInfo<void> page = _i3.PageInfo<void>(name);
+  static const _i4.PageInfo<void> page = _i4.PageInfo<void>(name);
 }
 
 /// generated route for
-/// [_i2.NewBreedingPage]
-class NewBreedingRoute extends _i3.PageRouteInfo<void> {
-  const NewBreedingRoute({List<_i3.PageRouteInfo>? children})
+/// [_i2.MaxIVFormPage]
+class MaxIVFormRoute extends _i4.PageRouteInfo<void> {
+  const MaxIVFormRoute({List<_i4.PageRouteInfo>? children})
+      : super(
+          MaxIVFormRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'MaxIVFormRoute';
+
+  static const _i4.PageInfo<void> page = _i4.PageInfo<void>(name);
+}
+
+/// generated route for
+/// [_i3.NewBreedingPage]
+class NewBreedingRoute extends _i4.PageRouteInfo<void> {
+  const NewBreedingRoute({List<_i4.PageRouteInfo>? children})
       : super(
           NewBreedingRoute.name,
           initialChildren: children,
@@ -57,5 +79,5 @@ class NewBreedingRoute extends _i3.PageRouteInfo<void> {
 
   static const String name = 'NewBreedingRoute';
 
-  static const _i3.PageInfo<void> page = _i3.PageInfo<void>(name);
+  static const _i4.PageInfo<void> page = _i4.PageInfo<void>(name);
 }

--- a/lib/views/pages/max_iv_form_page/max_iv_form_page.dart
+++ b/lib/views/pages/max_iv_form_page/max_iv_form_page.dart
@@ -1,0 +1,70 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:breeder/blocks/pages/max_iv_form/max_iv_form_cubit.dart';
+import 'package:breeder/shared/router/router.gr.dart';
+import 'package:breeder/views/pages/max_iv_form_page/max_iv_text_forms_widget.dart';
+import 'package:breeder/views/widgets/buttons/custom_text_button.dart';
+import 'package:breeder/views/widgets/generic/custom_container.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+@RoutePage()
+class MaxIVFormPage extends StatelessWidget {
+  const MaxIVFormPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider<MaxIVFormCubit>(
+      create: (_) => MaxIVFormCubit(),
+      child: Scaffold(
+        body: Center(
+          child: SingleChildScrollView(
+            child: CustomContainer(
+              containerWidth: 350,
+              containerHeight: 650,
+              columnItems: <Widget>[
+                Container(
+                  margin: const EdgeInsets.only(top: 30, left: 30, right: 30, bottom: 25),
+                  child: const Text(
+                    'Enter the quantity of monsters with maximum IVs',
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                      fontSize: 20,
+                      fontWeight: FontWeight.w400,
+                    ),
+                  ),
+                ),
+                const MaxIVTextFormsWidget(),
+                SizedBox(
+                  width: 300,
+                  child: Center(
+                    child: Row(
+                      children: <Widget>[
+                        CustomTextButton(
+                          buttonText: 'Back',
+                          icon: Icons.navigate_before,
+                          leftMargin: 25,
+                          onPressed: () => AutoRouter.of(context).push(const NewBreedingRoute()),
+                        ),
+                        CustomTextButton(
+                          buttonText: 'Cancel',
+                          icon: Icons.cancel,
+                          leftMargin: 25,
+                          onPressed: () => AutoRouter.of(context).push(const MainMenuRoute()),
+                        ),
+                        const CustomTextButton(
+                          buttonText: 'Next',
+                          icon: Icons.navigate_next,
+                          leftMargin: 25,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/pages/max_iv_form_page/max_iv_text_form_widget.dart
+++ b/lib/views/pages/max_iv_form_page/max_iv_text_form_widget.dart
@@ -1,0 +1,117 @@
+import 'package:breeder/blocks/pages/max_iv_form/a_max_iv_form_state.dart';
+import 'package:breeder/blocks/pages/max_iv_form/max_iv_form_cubit.dart';
+import 'package:breeder/blocks/pages/max_iv_form/states/max_iv_form_sum_calculated_state.dart';
+import 'package:breeder/config/locator.dart';
+import 'package:breeder/views/pages/max_iv_form_page/max_iv_value_limit_input_formatter.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class MaxIVTextFormWidget extends StatelessWidget {
+  final int _indexTextEditingControllerList;
+  final int _inputWeight;
+  final String _ivTextInfo;
+  final int _maxLength;
+  final int _maxSlots;
+  final MaxIVFormCubit _maxIVFormCubit = globalLocator<MaxIVFormCubit>();
+
+  MaxIVTextFormWidget({
+    required int indexTextEditingControllerList,
+    required int inputWeight,
+    required String ivTextInfo,
+    required int maxLength,
+    required int maxSlots,
+    Key? key,
+  })  : _indexTextEditingControllerList = indexTextEditingControllerList,
+        _inputWeight = inputWeight,
+        _ivTextInfo = ivTextInfo,
+        _maxLength = maxLength,
+        _maxSlots = maxSlots,
+        super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<MaxIVFormCubit, AMaxIVFormState>(
+      bloc: _maxIVFormCubit,
+      builder: (BuildContext context, AMaxIVFormState maxIVFormState) {
+        return Row(
+          children: <Widget>[
+            Column(
+              children: <Widget>[
+                Align(
+                  alignment: Alignment.topLeft,
+                  child: SizedBox(
+                    height: 44,
+                    width: 40,
+                    child: Text(
+                      _ivTextInfo,
+                      style: const TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w400,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            Expanded(
+              child: SizedBox(
+                width: 150,
+                child: TextFormField(
+                  controller: _getTextEditingController(_indexTextEditingControllerList),
+                  decoration: InputDecoration(
+                      isCollapsed: true,
+                      alignLabelWithHint: true,
+                      contentPadding: EdgeInsets.zero,
+                      labelStyle: const TextStyle(
+                        color: Color(0xFF727272),
+                        fontSize: 15,
+                        height: 0,
+                      ),
+                      enabledBorder: const UnderlineInputBorder(borderSide: BorderSide(color: Colors.black)),
+                      helperText: '${_calculateMaxIVAmountLeft(_inputWeight)} of ${_maxSlots} slots remaining',
+                      focusedBorder: const UnderlineInputBorder(borderSide: BorderSide(color: Colors.black)),
+                      floatingLabelBehavior: FloatingLabelBehavior.never),
+                  style: const TextStyle(
+                    fontSize: 15,
+                    color: Colors.black,
+                  ),
+                  keyboardType: TextInputType.number,
+                  inputFormatters: <TextInputFormatter>[
+                    FilteringTextInputFormatter.digitsOnly,
+                    LengthLimitingTextInputFormatter(_maxLength),
+                    MaxIVValueLimitInputFormatter(
+                      formsSum: _getMaxIVFormWeightedSum(maxIVFormState),
+                      inputWeight: _inputWeight,
+                    ),
+                  ],
+                  maxLines: 1,
+                  onChanged: (String value) {
+                    _maxIVFormCubit.calculateSum();
+                  },
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  // TODO(balladyna): After the MaxIVSlotsChangedState is called, the state remains unchanged thereafter, which can lead to problems in the future. Consider rewriting both the cubit and view.
+
+  int _getMaxIVFormWeightedSum(AMaxIVFormState maxIVFormState) {
+    if (maxIVFormState is MaxIVFormSumCalculatedState) {
+      return maxIVFormState.maxIVFormSum;
+    }
+    return 0;
+  }
+
+  int _calculateMaxIVAmountLeft(int inputWeight) {
+    return _maxIVFormCubit.maxIVFormModel.calculateAmountLeft(inputWeight);
+  }
+
+  TextEditingController _getTextEditingController(int indexTextEditingControllerList) {
+    return _maxIVFormCubit.maxIVFormModel.maxIVTextEditingControllersList[indexTextEditingControllerList];
+  }
+}

--- a/lib/views/pages/max_iv_form_page/max_iv_text_forms_widget.dart
+++ b/lib/views/pages/max_iv_form_page/max_iv_text_forms_widget.dart
@@ -1,0 +1,67 @@
+import 'package:breeder/views/pages/max_iv_form_page/max_iv_text_form_widget.dart';
+import 'package:flutter/material.dart';
+
+class MaxIVTextFormsWidget extends StatelessWidget {
+  const MaxIVTextFormsWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 200,
+      child: Column(
+        children: <Widget>[
+          Container(
+            margin: const EdgeInsets.only(top: 20, bottom: 40),
+            child: MaxIVTextFormWidget(
+              indexTextEditingControllerList: 0,
+              ivTextInfo: '1 IV',
+              maxLength: 2,
+              maxSlots: 32,
+              inputWeight: 1,
+            ),
+          ),
+          Container(
+            margin: const EdgeInsets.only(bottom: 40),
+            child: MaxIVTextFormWidget(
+              indexTextEditingControllerList: 1,
+              ivTextInfo: '2 IVs',
+              maxLength: 2,
+              maxSlots: 16,
+              inputWeight: 2,
+            ),
+          ),
+          Container(
+            margin: const EdgeInsets.only(bottom: 40),
+            child: MaxIVTextFormWidget(
+              indexTextEditingControllerList: 2,
+              ivTextInfo: '3 IVs',
+              maxLength: 1,
+              maxSlots: 8,
+              inputWeight: 4,
+            ),
+          ),
+          Container(
+            margin: const EdgeInsets.only(bottom: 40),
+            child: MaxIVTextFormWidget(
+              indexTextEditingControllerList: 3,
+              ivTextInfo: '4 IVs',
+              maxLength: 1,
+              maxSlots: 4,
+              inputWeight: 8,
+            ),
+          ),
+          Container(
+            margin: const EdgeInsets.only(bottom: 10),
+            child: MaxIVTextFormWidget(
+              indexTextEditingControllerList: 4,
+              ivTextInfo: '5 IVs',
+              maxLength: 1,
+              maxSlots: 2,
+              inputWeight: 16,
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/views/pages/max_iv_form_page/max_iv_value_limit_input_formatter.dart
+++ b/lib/views/pages/max_iv_form_page/max_iv_value_limit_input_formatter.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/services.dart';
+
+class MaxIVValueLimitInputFormatter extends TextInputFormatter {
+  final int _maxSlots = 32;
+  final int _inputWeight;
+  final int _formsSum;
+
+  MaxIVValueLimitInputFormatter({required int formsSum, required int inputWeight})
+      : _inputWeight = inputWeight,
+        _formsSum = formsSum;
+
+  @override
+  TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
+    int? newInputValue = int.tryParse(newValue.text);
+
+    if (newInputValue == null) {
+      return TextEditingValue.empty;
+    }
+
+    newInputValue *= _inputWeight;
+    int oldInputValue = (int.tryParse(oldValue.text) ?? 0) * _inputWeight;
+    int slotsRemaining = (_maxSlots + oldInputValue) - (_formsSum + newInputValue);
+
+    if (slotsRemaining >= 0) {
+      return newValue;
+    } else {
+      return oldValue;
+    }
+  }
+}

--- a/lib/views/pages/new_breeding_page.dart
+++ b/lib/views/pages/new_breeding_page.dart
@@ -68,10 +68,11 @@ class _NewBreedingState extends State<NewBreedingPage> {
                     leftMargin: 55,
                     onPressed: () => AutoRouter.of(context).push(const MainMenuRoute()),
                   ),
-                  const CustomTextButton(
+                  CustomTextButton(
                     buttonText: 'Next',
                     icon: Icons.navigate_next,
                     leftMargin: 55,
+                    onPressed: () => AutoRouter.of(context).push(const MaxIVFormRoute()),
                   ),
                 ],
               ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: breeder
 description: "The Breeder App is designed to assist users in breeding monsters with perfect combat characteristics."
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 0.0.3
+version: 0.0.4
 
 environment:
   sdk: ">=3.2.3"

--- a/test/unit/blocs/pages/max_iv_form/max_iv_form_cubit_test.dart
+++ b/test/unit/blocs/pages/max_iv_form/max_iv_form_cubit_test.dart
@@ -1,0 +1,46 @@
+import 'package:breeder/blocks/pages/max_iv_form/a_max_iv_form_state.dart';
+import 'package:breeder/blocks/pages/max_iv_form/max_iv_form_cubit.dart';
+import 'package:breeder/blocks/pages/max_iv_form/states/max_iv_form_init_state.dart';
+import 'package:breeder/blocks/pages/max_iv_form/states/max_iv_form_sum_calculated_state.dart';
+import 'package:breeder/config/locator.dart';
+import 'package:breeder/shared/models/max_iv_form/max_iv_form_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+//ignore_for_file: cascade_invocations
+
+Future<void> main() async {
+  await initLocator();
+
+  group('Tests of MaxIVFormCubit process', () {
+    MaxIVFormCubit actualMaxIVFormCubit = globalLocator<MaxIVFormCubit>();
+
+    MaxIVFormModel maxIVFormModel = MaxIVFormModel()
+      ..maxIVTextEditingControllersList[0].text = '2'
+      ..maxIVTextEditingControllersList[1].text = '1'
+      ..maxIVTextEditingControllersList[2].text = '1'
+      ..maxIVTextEditingControllersList[3].text = '1'
+      ..maxIVTextEditingControllersList[4].text = '1';
+
+    test('Should emit [AMaxIVFormState] state', () {
+      AMaxIVFormState expectedMaxIVFormInitState = MaxIVFormInitState();
+
+      expect(actualMaxIVFormCubit.state, expectedMaxIVFormInitState);
+    });
+
+    test('Should emit [MaxIVFormInitState] when [MaxIVSlotsModel] data is initialized', () {
+      actualMaxIVFormCubit.maxIVFormModel = maxIVFormModel;
+
+      AMaxIVFormState expectedMaxIVFormInitState = MaxIVFormInitState();
+
+      expect(actualMaxIVFormCubit.state, expectedMaxIVFormInitState);
+    });
+
+    test('Should return [MaxIVFormSumCalculatedState] if [maxIVFormSum value has changed]', () {
+      actualMaxIVFormCubit.calculateSum();
+
+      AMaxIVFormState expectedMaxIVFormSumCalculatedState = const MaxIVFormSumCalculatedState(maxIVFormSum: 32);
+
+      expect(actualMaxIVFormCubit.state, expectedMaxIVFormSumCalculatedState);
+    });
+  });
+}

--- a/test/unit/example_test.dart
+++ b/test/unit/example_test.dart
@@ -1,7 +1,0 @@
-import 'package:flutter_test/flutter_test.dart';
-
-void main() {
-    test('Test for true value', () {
-        expect(true, true);
-    });
-}

--- a/test/unit/shared/models/max_iv_form/max_iv_form_model_test.dart
+++ b/test/unit/shared/models/max_iv_form/max_iv_form_model_test.dart
@@ -1,0 +1,151 @@
+import 'package:breeder/shared/models/max_iv_form/max_iv_form_model.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Tests of MaxIVFormModel.getAmountList()', () {
+
+    final MaxIVFormModel maxIVFormModel = MaxIVFormModel();
+
+    test('Should return [all inputs] if [all inputs are digits]', () {
+      maxIVFormModel
+        ..maxIVTextEditingControllersList[0].text = '2'
+        ..maxIVTextEditingControllersList[1].text = '1'
+        ..maxIVTextEditingControllersList[2].text = '1'
+        ..maxIVTextEditingControllersList[3].text = '1'
+        ..maxIVTextEditingControllersList[4].text = '1';
+
+      List<int> actualAmountList = maxIVFormModel.getAmountList();
+
+      List<int> expectedAmountList = <int>[2, 1, 1, 1, 1];
+
+      expect(actualAmountList, expectedAmountList);
+    });
+
+    test('Should return [valid inputs and zeros] if [some inputs are empty]', () {
+      maxIVFormModel
+        ..maxIVTextEditingControllersList[0].text = '2'
+        ..maxIVTextEditingControllersList[1].text = ''
+        ..maxIVTextEditingControllersList[2].text = '2'
+        ..maxIVTextEditingControllersList[3].text = '1'
+        ..maxIVTextEditingControllersList[4].text = '';
+
+      List<int> actualAmountList = maxIVFormModel.getAmountList();
+
+      List<int> expectedAmountList = <int>[2, 0, 2, 1, 0];
+
+      expect(actualAmountList, expectedAmountList);
+    });
+
+    test('Should return [list with only zeros] if [all inputs are empty]', () {
+      for (TextEditingController textEditingController in maxIVFormModel.maxIVTextEditingControllersList) {
+        textEditingController.text = '';
+      }
+
+      List<int> actualAmountList = maxIVFormModel.getAmountList();
+
+      List<int> expectedAmountList = <int>[0, 0, 0, 0, 0];
+
+      expect(actualAmountList, expectedAmountList);
+    });
+  });
+
+  group('Tests of MaxIVFormModel.calculateWeightedSum()', () {
+
+    final MaxIVFormModel maxIVFormModel = MaxIVFormModel();
+
+    test('Should return [weighted sum of all inputs] if [all inputs are digits]', () {
+      maxIVFormModel
+        ..maxIVTextEditingControllersList[0].text = '2'
+        ..maxIVTextEditingControllersList[1].text = '1'
+        ..maxIVTextEditingControllersList[2].text = '1'
+        ..maxIVTextEditingControllersList[3].text = '1'
+        ..maxIVTextEditingControllersList[4].text = '1';
+
+      int actualCalculatedWeightedSum = maxIVFormModel.calculateWeightedSum();
+
+      int expectedCalculatedWeightedSum = 32;
+
+      expect(actualCalculatedWeightedSum, expectedCalculatedWeightedSum);
+    });
+
+    test('Should return [weighted sum of valid inputs] if [some inputs are empty]', () {
+      maxIVFormModel
+        ..maxIVTextEditingControllersList[0].text = '2'
+        ..maxIVTextEditingControllersList[1].text = ''
+        ..maxIVTextEditingControllersList[2].text = '2'
+        ..maxIVTextEditingControllersList[3].text = '1'
+        ..maxIVTextEditingControllersList[4].text = '';
+
+      int actualMaxIVSlotsWeightedSum = maxIVFormModel.calculateWeightedSum();
+
+      int expectedMaxIVSlotsWeightedSum = 18;
+
+      expect(actualMaxIVSlotsWeightedSum, expectedMaxIVSlotsWeightedSum);
+    });
+
+    test('Should return [zero] if [all inputs are empty]', () {
+      for (TextEditingController textEditingController in maxIVFormModel.maxIVTextEditingControllersList) {
+        textEditingController.text = '';
+      }
+
+      int actualCalculatedWeightedSum = maxIVFormModel.calculateWeightedSum();
+
+      int expectedCalculatedWeightedSum = 0;
+
+      expect(actualCalculatedWeightedSum, expectedCalculatedWeightedSum);
+    });
+  });
+
+  // TODO(balladyna): Consider creating tests that include all possible IV combinations for  MaxIVSlotsModel.calculateMaxIVAmountLeft().
+
+  group('Tests of MaxIVFormModel.calculateAmountLeft()', () {
+
+    final MaxIVFormModel maxIVFormModel = MaxIVFormModel();
+
+    test('Should return [CalculatedAmountLeft equal zero] if [all inputs are digits] and [weighted sum is 32]', () {
+      maxIVFormModel
+        ..maxIVTextEditingControllersList[0].text = '2'
+        ..maxIVTextEditingControllersList[1].text = '1'
+        ..maxIVTextEditingControllersList[2].text = '1'
+        ..maxIVTextEditingControllersList[3].text = '1'
+        ..maxIVTextEditingControllersList[4].text = '1';
+
+      int actualInputWeight = 2;
+      int actualCalculatedAmountLeft = maxIVFormModel.calculateAmountLeft(actualInputWeight);
+
+      int expectedCalculatedAmountLeft = 0;
+
+      expect(actualCalculatedAmountLeft, expectedCalculatedAmountLeft);
+    });
+
+    test('Should return [CalculatedAmountLeft > 0] if [some inputs are empty] and [weighted sum is greater than 0 but less than 32]', () {
+      maxIVFormModel
+        ..maxIVTextEditingControllersList[0].text = '2'
+        ..maxIVTextEditingControllersList[1].text = ''
+        ..maxIVTextEditingControllersList[2].text = '2'
+        ..maxIVTextEditingControllersList[3].text = '1'
+        ..maxIVTextEditingControllersList[4].text = '';
+
+      int actualInputWeight = 2;
+      int actualCalculatedAmountLeft = maxIVFormModel.calculateAmountLeft(actualInputWeight);
+
+      int expectedCalculatedAmountLeft = 7;
+
+      expect(actualCalculatedAmountLeft, expectedCalculatedAmountLeft);
+    });
+
+    test('Should return [CalculatedAmountLeft equal 32 divided by InputWeight] if [all inputs are empty]', () {
+      for (TextEditingController textEditingController in maxIVFormModel.maxIVTextEditingControllersList) {
+        textEditingController.text = '';
+      }
+
+      int actualInputWeight = 1;
+      int actualCalculatedAmountLeft = maxIVFormModel.calculateAmountLeft(actualInputWeight);
+
+      int expectedCalculatedAmountLeft = 32;
+
+      expect(actualCalculatedAmountLeft, expectedCalculatedAmountLeft);
+    });
+  });
+}

--- a/test/unit/views/max_iv_form_page/value_limit_input_formatter_test.dart
+++ b/test/unit/views/max_iv_form_page/value_limit_input_formatter_test.dart
@@ -1,0 +1,206 @@
+import 'package:breeder/views/pages/max_iv_form_page/max_iv_value_limit_input_formatter.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Tests of MaxIVValueLimitInputFormatter.formatEditUpdate()', () {
+    test('Should return [new value] if [old value is empty] and [new value does not exceed the limit]', () {
+      const int formsSum = 16;
+      const int inputWeight = 1;
+
+      MaxIVValueLimitInputFormatter actualMaxIVValueLimitInputFormatter =
+          MaxIVValueLimitInputFormatter(formsSum: formsSum, inputWeight: inputWeight);
+      TextEditingValue actualOldTextEditingValue = const TextEditingValue(
+        text: '',
+        selection: TextSelection.collapsed(offset: 0),
+      );
+
+      TextEditingValue actualNewTextEditingValue = const TextEditingValue(
+        text: '2',
+        selection: TextSelection.collapsed(offset: 1),
+      );
+
+      TextEditingValue actualTextEditingValue = actualMaxIVValueLimitInputFormatter.formatEditUpdate(
+        actualOldTextEditingValue,
+        actualNewTextEditingValue,
+      );
+
+      TextEditingValue expectedTextEditingValue = const TextEditingValue(
+        text: '2',
+        selection: TextSelection.collapsed(offset: 1),
+      );
+
+      expect(actualTextEditingValue, expectedTextEditingValue);
+    });
+
+    test('Should return [new value] if [new value does not exceed the limit]', () {
+      const int formsSum = 12;
+      const int inputWeight = 2;
+
+      MaxIVValueLimitInputFormatter actualMaxIVValueLimitInputFormatter =
+          MaxIVValueLimitInputFormatter(formsSum: formsSum, inputWeight: inputWeight);
+
+      TextEditingValue actualOldTextEditingValue = const TextEditingValue(
+        text: '2',
+        selection: TextSelection.collapsed(offset: 1),
+      );
+
+      TextEditingValue actualNewTextEditingValue = const TextEditingValue(
+        text: '7',
+        selection: TextSelection.collapsed(offset: 1),
+      );
+
+      TextEditingValue actualTextEditingValue = actualMaxIVValueLimitInputFormatter.formatEditUpdate(
+        actualOldTextEditingValue,
+        actualNewTextEditingValue,
+      );
+
+      TextEditingValue expectedTextEditingValue = const TextEditingValue(
+        text: '7',
+        selection: TextSelection.collapsed(offset: 1),
+      );
+
+      expect(actualTextEditingValue, expectedTextEditingValue);
+    });
+
+    test('Should return [new value] if [new value does not exceed the limit] and [cursor at the end]', () {
+      const int formsSum = 12;
+      const int inputWeight = 2;
+
+      MaxIVValueLimitInputFormatter actualMaxIVValueLimitInputFormatter =
+          MaxIVValueLimitInputFormatter(formsSum: formsSum, inputWeight: inputWeight);
+
+      TextEditingValue actualOldTextEditingValue = const TextEditingValue(
+        text: '2',
+        selection: TextSelection.collapsed(offset: 1),
+      );
+
+      TextEditingValue actualNewTextEditingValue = const TextEditingValue(
+        text: '10',
+        selection: TextSelection.collapsed(offset: 2),
+      );
+
+      TextEditingValue actualTextEditingValue = actualMaxIVValueLimitInputFormatter.formatEditUpdate(
+        actualOldTextEditingValue,
+        actualNewTextEditingValue,
+      );
+
+      TextEditingValue expectedTextEditingValue = const TextEditingValue(
+        text: '10',
+        selection: TextSelection.collapsed(offset: 2),
+      );
+
+      expect(actualTextEditingValue, expectedTextEditingValue);
+    });
+
+    test('Should return [new value] if [new value does not exceed the limit] and [cursor at the beginning]', () {
+      const int formsSum = 12;
+      const int inputWeight = 4;
+
+      MaxIVValueLimitInputFormatter actualMaxIVValueLimitInputFormatter =
+          MaxIVValueLimitInputFormatter(formsSum: formsSum, inputWeight: inputWeight);
+      TextEditingValue actualOldTextEditingValue = const TextEditingValue(
+        text: '2',
+        selection: TextSelection.collapsed(offset: 1),
+      );
+
+      TextEditingValue actualNewTextEditingValue = const TextEditingValue(
+        text: '4',
+        selection: TextSelection.collapsed(offset: 0),
+      );
+
+      TextEditingValue actualTextEditingValue = actualMaxIVValueLimitInputFormatter.formatEditUpdate(
+        actualOldTextEditingValue,
+        actualNewTextEditingValue,
+      );
+
+      TextEditingValue expectedTextEditingValue = const TextEditingValue(
+        text: '4',
+        selection: TextSelection.collapsed(offset: 0),
+      );
+
+      expect(actualTextEditingValue, expectedTextEditingValue);
+    });
+
+    test('Should return [old value] if [new value exceed the limit]', () {
+      const int formsSum = 12;
+      const int inputWeight = 16;
+
+      MaxIVValueLimitInputFormatter actualMaxIVValueLimitInputFormatter =
+          MaxIVValueLimitInputFormatter(formsSum: formsSum, inputWeight: inputWeight);
+      TextEditingValue actualOldTextEditingValue = const TextEditingValue(
+        text: '1',
+        selection: TextSelection.collapsed(offset: 1),
+      );
+
+      TextEditingValue actualNewTextEditingValue = const TextEditingValue(
+        text: '24',
+        selection: TextSelection.collapsed(offset: 1),
+      );
+
+      TextEditingValue actualTextEditingValue = actualMaxIVValueLimitInputFormatter.formatEditUpdate(
+        actualOldTextEditingValue,
+        actualNewTextEditingValue,
+      );
+
+      TextEditingValue expectedTextEditingValue = const TextEditingValue(
+        text: '1',
+        selection: TextSelection.collapsed(offset: 1),
+      );
+
+      expect(actualTextEditingValue, expectedTextEditingValue);
+    });
+
+    test('Should return [an empty field] if [new value is empty]', () {
+      const int formsSum = 12;
+      const int inputWeight = 16;
+
+      MaxIVValueLimitInputFormatter actualMaxIVValueLimitInputFormatter =
+          MaxIVValueLimitInputFormatter(formsSum: formsSum, inputWeight: inputWeight);
+      TextEditingValue actualOldTextEditingValue = const TextEditingValue(
+        text: '1',
+        selection: TextSelection.collapsed(offset: 1),
+      );
+
+      TextEditingValue actualNewTextEditingValue = const TextEditingValue(
+        text: '',
+        selection: TextSelection.collapsed(offset: 0),
+      );
+
+      TextEditingValue actualTextEditingValue = actualMaxIVValueLimitInputFormatter.formatEditUpdate(
+        actualOldTextEditingValue,
+        actualNewTextEditingValue,
+      );
+
+      TextEditingValue expectedTextEditingValue = TextEditingValue.empty;
+
+      expect(actualTextEditingValue, expectedTextEditingValue);
+    });
+
+    test('Should return [an empty field] if [new value is not composed of digits]', () {
+      const int formsSum = 12;
+      const int inputWeight = 16;
+
+      MaxIVValueLimitInputFormatter actualMaxIVValueLimitInputFormatter =
+          MaxIVValueLimitInputFormatter(formsSum: formsSum, inputWeight: inputWeight);
+      TextEditingValue actualOldTextEditingValue = const TextEditingValue(
+        text: '1',
+        selection: TextSelection.collapsed(offset: 1),
+      );
+
+      TextEditingValue actualNewTextEditingValue = const TextEditingValue(
+        text: 'asd',
+        selection: TextSelection.collapsed(offset: 3),
+      );
+
+      TextEditingValue actualTextEditingValue = actualMaxIVValueLimitInputFormatter.formatEditUpdate(
+        actualOldTextEditingValue,
+        actualNewTextEditingValue,
+      );
+
+      TextEditingValue expectedTextEditingValue = TextEditingValue.empty;
+
+      expect(actualTextEditingValue, expectedTextEditingValue);
+    });
+  });
+}


### PR DESCRIPTION
This feature introduces the Max IV Form page where users can input the number of monsters they have based on their IV. The application validates user input for correctness.

List of changes:
- created max_iv_form_page.dart, max_iv_text_form_widget.dart and max_iv_text_forms_widget.dart allowing users to input information about the number of max IV
- created max_iv_value_limit_input_formatter.dart to enforce input limits based on predefined constraints ensuring the maximum sum of slots has not exceeded
- created max_iv_text_editing_controllers.dart which are used in max_iv_text_form_widget.dart
- created max_iv_form_model.dart to parse data from textEditingControllers (from string to int), calculate weighted sum of parsed textEditingControllers (calculations are based on the assumption that each IV has its own weight) and determine still available IVs to use
- created max_iv_slots_cubit.dart to manage states of TextForms
- created unit tests – max_iv_form_cubit_test.dart, max_iv_form_model_test.dart and value_limit_input_formatter_test.dart to verify their functionality with input scenarios